### PR TITLE
No row in dict.csv for smaller set of points

### DIFF
--- a/khooshe/khooshe.py
+++ b/khooshe/khooshe.py
@@ -154,9 +154,9 @@ def make_rest_of_layers(data, centroids, shapes, centroids_number, tile_name):
         data = new_datas
         new_datas = 0
         count += 1
-        if data == {}:
-            break
         make_dictionary(temp, tile_name)
+        if data == {} and cluster:
+            break
 
 
 def run_khooshe(points_obj, points_file, tile_name):


### PR DESCRIPTION
sample_points.csv

32.85065,-79.82894
33.74368,-115.99386

generates 2 zoom level -> 0,1. 0/0.csv with 2 points and 1/0.csv,
1/1.csv files each with single point BUT dict.csv have only one row

dict.csv

folder,file,extent
0,0,"-115.99386, 32.85065, -79.82894, 33.74368"
No rows for 1/0.csv and 1/1.csv
